### PR TITLE
handle the case when the battery is "100%; charged;" on macOS.

### DIFF
--- a/lib/AngelPS1/System/darwin.pm
+++ b/lib/AngelPS1/System/darwin.pm
@@ -43,14 +43,14 @@ sub gen_fetch_battery
     return sub {
         my $pmset_batt = `pmset -g batt`;
 
+        # 100%; charged;
         # 37%; AC attached; not charging
         # 8%; charging; 2:46 remaining
         # 9%; discharging; (no estimate)
         # 7%; discharging; 0:13 remaining
-        $pmset_batt =~ m/\t([0-9]+)%;.* (dis)?charging/;
+        $pmset_batt =~ m/\t([0-9]+)%;.* (dis)?charg(ing|ed)/;
         my $level = $1 / 100;
         my $charging = ! defined $2;
-
         return ($level, $charging);
     }
 }


### PR DESCRIPTION
This also fix a warning about `$1` being undef.

When fully changed, the output of `pmset -g batt` is:

    Now drawing from 'AC Power'
     -InternalBattery-0 (id=4391011)	100%; charged; 0:00 remaining present: true

osx version: 10.13.6